### PR TITLE
Type-hint the Permissions Contract

### DIFF
--- a/src/Permissions/DoctrinePermissionDriver.php
+++ b/src/Permissions/DoctrinePermissionDriver.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Illuminate\Contracts\Config\Repository;
+use LaravelDoctrine\ACL\Contracts\Permission;
 use Illuminate\Support\Collection;
 
 class DoctrinePermissionDriver implements PermissionDriver

--- a/src/Permissions/DoctrinePermissionDriver.php
+++ b/src/Permissions/DoctrinePermissionDriver.php
@@ -6,8 +6,8 @@ use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Illuminate\Contracts\Config\Repository;
-use LaravelDoctrine\ACL\Contracts\Permission;
 use Illuminate\Support\Collection;
+use LaravelDoctrine\ACL\Contracts\Permission;
 
 class DoctrinePermissionDriver implements PermissionDriver
 {


### PR DESCRIPTION
So that custom Permissions classes can be used.
Docs say `You can replace that one by your own inside the config as long as it implements the LaravelDoctrine\ACL\Contracts\Permission interface.`  
Doing so throws an exception when using DoctrinePermissionsDriver:
`
[ErrorException]                                                                                                   
  Argument 1 passed to LaravelDoctrine\ACL\Permissions\DoctrinePermissionDriver::LaravelDoctrine\ACL\Permissions\{closure}() must be an instance of LaravelDoctrine\ACL\Permissions\Permission, 
  instance of Your\Custom\Domain\Model\Authorization\Permission given  
`
