### PR TITLE
Trait improvements

### DIFF
--- a/src/Organisations/BelongsToOrganisation.php
+++ b/src/Organisations/BelongsToOrganisation.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: mduncan
+ * Date: 10/16/15
+ * Time: 10:29 AM
+ */
+namespace LaravelDoctrine\ACL\Organisations;
+
+use LaravelDoctrine\ACL\Contracts\BelongsToOrganisation as BelongsToOrganisationContract;
+use LaravelDoctrine\ACL\Contracts\BelongsToOrganisations as BelongsToOrganisationsContract;
+use LaravelDoctrine\ACL\Contracts\Organisation as OrganisationContract;
+
+trait BelongsToOrganisation
+{
+    /**
+     * @param  OrganisationContract|string|array $org
+     * @param  bool                              $requireAll
+     * @return bool
+     */
+    public function belongsToOrganisation($org, $requireAll = false)
+    {
+        if (is_array($org)) {
+            foreach ($org as $o) {
+                $hasOrganisation = $this->belongsToOrganisation($o);
+
+                if ($hasOrganisation && !$requireAll) {
+                    return true;
+                } elseif (!$hasOrganisation && $requireAll) {
+                    return false;
+                }
+            }
+
+            return $requireAll;
+        } else {
+            if ($this instanceof BelongsToOrganisationContract) {
+                if (!is_null($this->getOrganisation()) && $this->getOrganisationName($org) === $this->getOrganisation()->getName()) {
+                    return true;
+                }
+            }
+            if ($this instanceof BelongsToOrganisationsContract) {
+                foreach ($this->getOrganisations() as $o) {
+                    if ($this->getOrganisationName($org) === $o->getName()) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+
+    /**
+     * @param OrganisationContract|string $org
+     *
+     * @return string
+     */
+    protected function getOrganisationName($org)
+    {
+        return $org instanceof OrganisationContract ? $org->getName() : $org;
+    }
+}

--- a/src/Roles/HasRoles.php
+++ b/src/Roles/HasRoles.php
@@ -7,15 +7,29 @@ use LaravelDoctrine\ACL\Contracts\Role;
 trait HasRoles
 {
     /**
-     * @param Role $role
-     *
+     * @param  Role|array $role
+     * @param  bool       $requireAll
      * @return bool
      */
-    public function hasRole(Role $role)
+    public function hasRole($role, $requireAll = false)
     {
-        foreach ($this->getRoles() as $ownedRole) {
-            if ($ownedRole === $role) {
-                return true;
+        if (is_array($role)) {
+            foreach ($role as $r) {
+                $hasRole = $this->hasRole($r);
+
+                if ($hasRole && !$requireAll) {
+                    return true;
+                } elseif (!$hasRole && $requireAll) {
+                    return false;
+                }
+            }
+
+            return $requireAll;
+        } else {
+            foreach ($this->getRoles() as $ownedRole) {
+                if ($ownedRole === $role) {
+                    return true;
+                }
             }
         }
 
@@ -23,15 +37,29 @@ trait HasRoles
     }
 
     /**
-     * @param string $name
-     *
+     * @param  string|array $name
+     * @param  bool         $requireAll
      * @return bool
      */
-    public function hasRoleByName($name)
+    public function hasRoleByName($name, $requireAll = false)
     {
-        foreach ($this->getRoles() as $ownedRole) {
-            if ($ownedRole->getName() === $name) {
-                return true;
+        if (is_array($name)) {
+            foreach ($name as $n) {
+                $hasRole = $this->hasRoleByName($n);
+
+                if ($hasRole && !$requireAll) {
+                    return true;
+                } elseif (!$hasRole && $requireAll) {
+                    return false;
+                }
+            }
+
+            return $requireAll;
+        } else {
+            foreach ($this->getRoles() as $ownedRole) {
+                if ($ownedRole->getName() === $name) {
+                    return true;
+                }
             }
         }
 

--- a/tests/Organisations/BelongsToOrganisationTest.php
+++ b/tests/Organisations/BelongsToOrganisationTest.php
@@ -1,0 +1,208 @@
+<?php
+
+
+class BelongsToOrganisationTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var UserMock3
+     */
+    protected $user;
+
+    /**
+     * @var UserMock4
+     */
+    protected $userSingle;
+
+    /**
+     * @var OrgMock
+     */
+    protected $orgMock1;
+    /**
+     * @var OrgMock
+     */
+    protected $orgMock2;
+    /**
+     * @var OrgMock
+     */
+    protected $orgMock3;
+
+    protected function setUp()
+    {
+        $this->user          = new UserMock3;
+        $this->userSingle    = new UserMock4;
+        $this->orgMock1      = new OrgMock('org1');
+        $this->orgMock2      = new OrgMock('org2');
+        $this->orgMock3      = new OrgMock('org3');
+    }
+
+    public function test_doesnt_have_organisation_when_no_organisations_assigned_single()
+    {
+        $this->assertFalse($this->userSingle->belongsToOrganisation($this->orgMock1));
+    }
+
+    public function test_doesnt_have_organisation_when_no_organisations_assigned()
+    {
+        $this->assertFalse($this->user->belongsToOrganisation($this->orgMock1));
+    }
+
+    public function test_doesnt_have_role_by_name_when_no_roles_assigned()
+    {
+        $this->assertFalse($this->user->belongsToOrganisation('org1'));
+    }
+
+    public function test_doesnt_have_organisation_when_when_other_orgiansation_assigned()
+    {
+        $this->user->setOrganisations([
+            new OrgMock('org4'),
+        ]);
+        $this->assertFalse($this->user->belongsToOrganisation($this->orgMock1));
+    }
+
+    public function test_doesnt_have_any_organisations_when_organisation_assigned()
+    {
+        $this->user->setOrganisations([
+            $this->orgMock1
+        ]);
+        $this->assertFalse($this->user->belongsToOrganisation([$this->orgMock2, $this->orgMock3]));
+    }
+
+    public function test_doesnt_have_any_organisation_by_name_when_organisation_assigned()
+    {
+        $this->user->setOrganisations([
+            $this->orgMock1
+        ]);
+        $this->assertFalse($this->user->belongsToOrganisation(['org2', 'org3']));
+    }
+
+    public function test_doesnt_have_all_organisations_when_organisations_assigned()
+    {
+        $this->user->setOrganisations([
+            $this->orgMock1,
+            $this->orgMock2
+        ]);
+        $this->assertFalse($this->user->belongsToOrganisation([$this->orgMock1, $this->orgMock2, $this->orgMock3], true));
+    }
+
+    public function test_doesnt_have_all_organisations_by_name_when_organisations_assigned()
+    {
+        $this->user->setOrganisations([
+            $this->orgMock1,
+            $this->orgMock2
+        ]);
+        $this->assertFalse($this->user->belongsToOrganisation(['org1', 'org2', 'org3'], true));
+    }
+
+    public function test_has_organisation_when_when_organisation_assigned()
+    {
+        $this->user->setOrganisations([
+            $this->orgMock1,
+        ]);
+        $this->assertTrue($this->user->belongsToOrganisation($this->orgMock1));
+    }
+
+    public function test_has_organisation_by_name_when_when_organisation_assigned()
+    {
+        $this->user->setOrganisations([
+            $this->orgMock1,
+        ]);
+        $this->assertTrue($this->user->belongsToOrganisation('org1'));
+    }
+
+    public function test_has_any_organisation_when_organisation_assigned()
+    {
+        $this->user->setOrganisations([
+            $this->orgMock1,
+            $this->orgMock2,
+            $this->orgMock3
+        ]);
+        $this->assertTrue($this->user->belongsToOrganisation([$this->orgMock1, $this->orgMock2]));
+    }
+
+    public function test_has_all_organisations_when_organisations_assigned()
+    {
+        $this->user->setOrganisations([
+            $this->orgMock1,
+            $this->orgMock2,
+            $this->orgMock3
+        ]);
+        $this->assertTrue($this->user->belongsToOrganisation([$this->orgMock1, $this->orgMock2, $this->orgMock3], true));
+    }
+
+    public function test_has_any_organisation_by_name_when_organisation_assigned()
+    {
+        $this->user->setOrganisations([
+            $this->orgMock1,
+            $this->orgMock2,
+            $this->orgMock3
+        ]);
+        $this->assertTrue($this->user->belongsToOrganisation(['org1', 'org4']));
+    }
+
+    public function test_has_all_organisations_by_name_when_organisations_assigned()
+    {
+        $this->user->setOrganisations([
+            $this->orgMock1,
+            $this->orgMock2,
+            $this->orgMock3
+        ]);
+        $this->assertTrue($this->user->belongsToOrganisation(['org1', 'org2', 'org3'], true));
+    }
+}
+
+class UserMock3 implements \LaravelDoctrine\ACL\Contracts\BelongsToOrganisations
+{
+    use \LaravelDoctrine\ACL\Organisations\BelongsToOrganisation;
+
+    protected $organisations = [];
+
+    public function getOrganisations()
+    {
+        return $this->organisations;
+    }
+
+    public function setOrganisations($orgs)
+    {
+        $this->organisations = $orgs;
+    }
+}
+
+class UserMock4 implements \LaravelDoctrine\ACL\Contracts\BelongsToOrganisation
+{
+    use \LaravelDoctrine\ACL\Organisations\BelongsToOrganisation;
+
+    protected $organisation;
+
+    public function getOrganisation()
+    {
+        return $this->organisation;
+    }
+
+    public function setOrganisation($org)
+    {
+        $this->organisation = $org;
+    }
+}
+
+class OrgMock implements \LaravelDoctrine\ACL\Contracts\Organisation
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @param $name
+     */
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/tests/Permissions/HasPermissionsTest.php
+++ b/tests/Permissions/HasPermissionsTest.php
@@ -69,6 +69,25 @@ class HasPermissionsTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($this->userWithRoles->hasPermissionTo('create.post'));
     }
 
+    public function test_doesnt_have_permission_with_permission_but_no_other_permissions()
+    {
+        $this->user->setPermissions([
+            'create.page',
+        ]);
+
+        $this->assertFalse($this->user->hasPermissionTo(['create.post', 'create.comment']));
+    }
+
+    public function test_doesnt_have_permission_with_permission_but_not_all_other_permissions()
+    {
+        $this->user->setPermissions([
+            'create.page',
+            'create.post'
+        ]);
+
+        $this->assertFalse($this->user->hasPermissionTo(['create.post', 'create.page', 'create.comment'], true));
+    }
+
     public function test_user_has_permission_when_no_roles_but_has_the_permission()
     {
         $this->user->setPermissions([
@@ -141,6 +160,25 @@ class HasPermissionsTest extends PHPUnit_Framework_TestCase
         ]);
 
         $this->assertTrue($this->userWithRoles->hasPermissionTo('create.post'));
+    }
+
+    public function test_has_permission_with_permission_but_not_all_other_permissions()
+    {
+        $this->user->setPermissions([
+            'create.page',
+        ]);
+
+        $this->assertTrue($this->user->hasPermissionTo(['create.post', 'create.page', 'create.comment']));
+    }
+
+    public function test_has_permission_and_all_permissions()
+    {
+        $this->user->setPermissions([
+            'create.page',
+            'create.post'
+        ]);
+
+        $this->assertTrue($this->user->hasPermissionTo(['create.post', 'create.page'], true));
     }
 }
 

--- a/tests/Roles/HasRolesTest.php
+++ b/tests/Roles/HasRolesTest.php
@@ -16,11 +16,21 @@ class HasRolesTest extends PHPUnit_Framework_TestCase
      * @var RoleMock2
      */
     protected $admin;
+    /**
+     * @var RoleMock2
+     */
+    protected $extraRole1;
+    /**
+     * @var RoleMock2
+     */
+    protected $extraRole2;
 
     protected function setUp()
     {
-        $this->user  = new UserMock2;
-        $this->admin = new RoleMock2('admin');
+        $this->user       = new UserMock2;
+        $this->admin      = new RoleMock2('admin');
+        $this->extraRole1 = new RoleMock2('extraRole1');
+        $this->extraRole2 = new RoleMock2('extraRole2');
     }
 
     public function test_doesnt_have_role_when_no_roles_assigned()
@@ -39,6 +49,40 @@ class HasRolesTest extends PHPUnit_Framework_TestCase
             new RoleMock2('user'),
         ]);
         $this->assertFalse($this->user->hasRole($this->admin));
+    }
+
+    public function test_doesnt_have_any_role_when_role_assigned()
+    {
+        $this->user->setRoles([
+            $this->admin
+        ]);
+        $this->assertFalse($this->user->hasRole([$this->extraRole1, $this->extraRole2]));
+    }
+
+    public function test_doesnt_have_any_role_by_name_when_role_assigned()
+    {
+        $this->user->setRoles([
+            $this->admin
+        ]);
+        $this->assertFalse($this->user->hasRoleByName(['extraRole1', 'extraRole2']));
+    }
+
+    public function test_doesnt_have_all_roles_when_role_assigned()
+    {
+        $this->user->setRoles([
+            $this->admin,
+            $this->extraRole1
+        ]);
+        $this->assertFalse($this->user->hasRole([$this->admin, $this->extraRole1, $this->extraRole2], true));
+    }
+
+    public function test_doesnt_have_all_roles_by_name_when_role_assigned()
+    {
+        $this->user->setRoles([
+            $this->admin,
+            $this->extraRole1
+        ]);
+        $this->assertFalse($this->user->hasRoleByName(['admin', 'extraRole1', 'extraRole2'], true));
     }
 
     public function test_doesnt_have_role_by_name_when_when_other_role_assigned()
@@ -63,6 +107,46 @@ class HasRolesTest extends PHPUnit_Framework_TestCase
             $this->admin,
         ]);
         $this->assertTrue($this->user->hasRoleByName('admin'));
+    }
+
+    public function test_has_any_role_when_role_assigned()
+    {
+        $this->user->setRoles([
+            $this->admin,
+            $this->extraRole1,
+            $this->extraRole2
+        ]);
+        $this->assertTrue($this->user->hasRole([$this->admin, $this->extraRole1]));
+    }
+
+    public function test_has_all_role_when_role_assigned()
+    {
+        $this->user->setRoles([
+            $this->admin,
+            $this->extraRole1,
+            $this->extraRole2
+        ]);
+        $this->assertTrue($this->user->hasRole([$this->admin, $this->extraRole1, $this->extraRole2], true));
+    }
+
+    public function test_has_any_role_by_name_when_role_assigned()
+    {
+        $this->user->setRoles([
+            $this->admin,
+            $this->extraRole1,
+            $this->extraRole2
+        ]);
+        $this->assertTrue($this->user->hasRoleByName(['admin', 'extraRole1']));
+    }
+
+    public function test_has_all_role_by_name_when_role_assigned()
+    {
+        $this->user->setRoles([
+            $this->admin,
+            $this->extraRole1,
+            $this->extraRole2
+        ]);
+        $this->assertTrue($this->user->hasRoleByName(['admin', 'extraRole1', 'extraRole2'], true));
     }
 }
 


### PR DESCRIPTION
This PR
- Expands the functionality of the `HasRoles` and `HasPermissions` traits to allow testing for one **or more** associations
- Implements a `BelongsToOrganisation` trait that provides similar functionality to the previous mentioned traits
- Tests for all of the above

These changes are non-breaking.
