### PR TITLE
Made the AclServiceProvider more intelligent when loading the Permission Entity

### DIFF
--- a/src/AclServiceProvider.php
+++ b/src/AclServiceProvider.php
@@ -29,7 +29,7 @@ class AclServiceProvider extends ServiceProvider
 
         $manager->extendAll(RegisterMappedEventSubscribers::class);
 
-        if ($permissionManager->needsDoctrine()) {
+        if ($permissionManager->useDefaultPermissionEntity()) {
             $manager->addPaths([
                 __DIR__ . DIRECTORY_SEPARATOR . 'Permissions',
             ]);

--- a/src/Permissions/PermissionManager.php
+++ b/src/Permissions/PermissionManager.php
@@ -72,6 +72,21 @@ class PermissionManager extends Manager
     /**
      * @return bool
      */
+    public function useDefaultPermissionEntity()
+    {
+        if (!$this->needsDoctrine()) {
+            return false;
+        }
+
+        $entityFqn = $this->container->make('config')->get('acl.permissions.entity', '');
+        $entityFqn = ltrim($entityFqn, "\\");
+
+        return $entityFqn === Permission::class;
+    }
+
+    /**
+     * @return bool
+     */
     public function needsDoctrine()
     {
         return $this->getDefaultDriver() === 'doctrine';

--- a/tests/Permissions/PermissionManagerTest.php
+++ b/tests/Permissions/PermissionManagerTest.php
@@ -2,21 +2,42 @@
 
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\Collection;
+use LaravelDoctrine\ACL\Permissions\Permission;
 use LaravelDoctrine\ACL\Permissions\PermissionDriver;
 use LaravelDoctrine\ACL\Permissions\PermissionManager;
 use Mockery as m;
 
 class PermissionManagerTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @var PermissionDriver
+     */
     protected $driver;
 
+    /**
+     * @var PermissionManager
+     */
     protected $manager;
 
+    /**
+     * @var Container
+     */
     protected $container;
 
     protected function setUp()
     {
         $this->driver = m::mock(PermissionDriver::class);
+
+        $this->container = m::mock(Container::class);
+
+        $this->manager = new PermissionManager($this->container);
+        $this->manager->extend('config', function () {
+            return $this->driver;
+        });
+    }
+
+    public function test_can_dot_notated_array_of_permissions()
+    {
         $this->driver->shouldReceive('getAllPermissions')->once()->andReturn(new Collection([
             'permission1',
             'permissionKey2' => [
@@ -31,21 +52,12 @@ class PermissionManagerTest extends PHPUnit_Framework_TestCase
             ]
         ]));
 
-        $this->container = m::mock(Container::class);
-        $config          = m::mock(Config::class);
+        $config = m::mock(Config::class);
 
         $this->container->shouldReceive('make')->with('config')->andReturn($config);
 
         $config->shouldReceive('get')->with('acl.permissions.driver', 'config')->andReturn('config');
 
-        $this->manager = new PermissionManager($this->container);
-        $this->manager->extend('config', function () {
-            return $this->driver;
-        });
-    }
-
-    public function test_can_dot_notated_array_of_permissions()
-    {
         $this->assertEquals([
             'permission1',
             'permissionKey2.permissionValue1',
@@ -53,5 +65,65 @@ class PermissionManagerTest extends PHPUnit_Framework_TestCase
             'permissionKey3.permissionKey4.permissionValue3',
             'permissionKey3.permissionKey4.permissionValue4'
         ], $this->manager->getPermissionsWithDotNotation());
+    }
+
+    public function test_when_should_use_default_permission_entity()
+    {
+        $config = m::mock(Config::class);
+
+        $this->container->shouldReceive('make')->with('config')->andReturn($config);
+
+        $config->shouldReceive('get')->with('acl.permissions.driver', 'config')->andReturn('doctrine');
+
+        // Tests for leading slashes in case someone is providing a manually written FQN
+        $config->shouldReceive('get')->with('acl.permissions.entity', null)->andReturn("\\" . Permission::class);
+
+        $this->assertTrue($this->manager->useDefaultPermissionEntity());
+    }
+
+    public function test_when_should_not_use_default_permission_entity_because_driver_is_not_doctrine()
+    {
+        $config = m::mock(Config::class);
+
+        $this->container->shouldReceive('make')->with('config')->andReturn($config);
+
+        $config->shouldReceive('get')->with('acl.permissions.driver', 'config')->andReturn('config');
+        $config->shouldReceive('get')->with('acl.permissions.entity', null)->andReturn(Permission::class);
+
+        $this->assertFalse($this->manager->useDefaultPermissionEntity());
+    }
+
+    public function test_when_should_not_use_default_permission_entity_because_entity_is_different()
+    {
+        $config = m::mock(Config::class);
+
+        $this->container->shouldReceive('make')->with('config')->andReturn($config);
+
+        $config->shouldReceive('get')->with('acl.permissions.driver', 'config')->andReturn('config');
+        $config->shouldReceive('get')->with('acl.permissions.entity', null)->andReturn('Namespace\Class');
+
+        $this->assertFalse($this->manager->useDefaultPermissionEntity());
+    }
+
+    public function test_needs_doctrine()
+    {
+        $config = m::mock(Config::class);
+
+        $this->container->shouldReceive('make')->with('config')->andReturn($config);
+
+        $config->shouldReceive('get')->with('acl.permissions.driver', 'config')->andReturn('doctrine');
+
+        $this->assertTrue($this->manager->needsDoctrine());
+    }
+
+    public function test_does_not_need_doctrine()
+    {
+        $config = m::mock(Config::class);
+
+        $this->container->shouldReceive('make')->with('config')->andReturn($config);
+
+        $config->shouldReceive('get')->with('acl.permissions.driver', 'config')->andReturn('config');
+
+        $this->assertFalse($this->manager->needsDoctrine());
     }
 }


### PR DESCRIPTION
Allows users to have their own permission with the table name 'permissions'
