### PR TITLE
Add addPermission methods to Permission Contract and Trait

### DIFF
--- a/src/Contracts/HasPermissions.php
+++ b/src/Contracts/HasPermissions.php
@@ -17,4 +17,11 @@ interface HasPermissions
      * @return ArrayCollection|Permission[]
      */
     public function getPermissions();
+    
+    /**
+     * @param PermissionContract|string $permission
+     *
+     * @return string
+     */
+    public function addPermission($permission);
 }

--- a/src/Contracts/HasPermissions.php
+++ b/src/Contracts/HasPermissions.php
@@ -17,7 +17,7 @@ interface HasPermissions
      * @return ArrayCollection|Permission[]
      */
     public function getPermissions();
-    
+
     /**
      * @param PermissionContract|string $permission
      *

--- a/src/Permissions/HasPermissions.php
+++ b/src/Permissions/HasPermissions.php
@@ -65,7 +65,7 @@ trait HasPermissions
      *
      * @return string
      */
-    protected function addPermission($permission)
+    public function addPermission($permission)
     {
         // Assumes self::$permissions is an instance of ArrayCollection
         if ($permission instanceof PermissionContract) {

--- a/src/Permissions/HasPermissions.php
+++ b/src/Permissions/HasPermissions.php
@@ -59,4 +59,24 @@ trait HasPermissions
     {
         return $permission instanceof PermissionContract ? $permission->getName() : $permission;
     }
+    
+    /**
+     * @param PermissionContract|string $permission
+     *
+     * @return string
+     */
+    protected function addPermission($permission)
+    {
+        // Assumes self::$permissions is an instance of ArrayCollection
+        if ($permission instanceof PermissionContract) {
+            $this->permissions->add($permission);
+        }
+        
+        // Assumes self::$permissions is an array, and will be stored as a json_array column
+        if (is_string($permission)) {
+            $this->permissions[] = $permission;
+        }
+        
+        return $this;
+    }
 }

--- a/src/Permissions/HasPermissions.php
+++ b/src/Permissions/HasPermissions.php
@@ -59,7 +59,7 @@ trait HasPermissions
     {
         return $permission instanceof PermissionContract ? $permission->getName() : $permission;
     }
-    
+
     /**
      * @param PermissionContract|string $permission
      *
@@ -71,12 +71,12 @@ trait HasPermissions
         if ($permission instanceof PermissionContract) {
             $this->permissions->add($permission);
         }
-        
+
         // Assumes self::$permissions is an array, and will be stored as a json_array column
         if (is_string($permission)) {
             $this->permissions[] = $permission;
         }
-        
+
         return $this;
     }
 }


### PR DESCRIPTION
After working with the `config` driver for a bit, I was having trouble getting the permissions to store on my role object's permissions db column correctly.  After awhile, I noticed that it was an empty JSON Object instead of an empty array (doh).

Having an `addPermission` method on the contract and trait would facilitate the "up and running" time fo using the ACL module, as it helps makes more clear that two different types of data are accepted.

There may be an opportunity to clarify the docs a bit on this front as well, letting people know that when using the `config` driver, their `$permissions` property should be an `array` (so that it is storable as json), and when they are using the `doctrine` driver, `$permissions` should be an `ArrayCollection`.  I would be happy to PR that change on the laravel-doctrine/docs repo if you'd like.
