### PR TITLE
Updated method createDriver() signature

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -16,7 +16,7 @@ abstract class Manager extends ConfigurationManager
      * @throws DriverNotFound
      * @return mixed
      */
-    protected function createDriver($driver, array $settings = [])
+    protected function createDriver($driver, array $settings = [], $resolve = true)
     {
         $class = $this->getNamespace() . '\\' . studly_case($driver) . $this->getClassSuffix();
 


### PR DESCRIPTION
LaravelDoctrine\ORM\Configuration\Manager had an update [https://github.com/laravel-doctrine/orm/commit/0da17443e178fa6947dd701f7b6241ce3fd7c5a7] which caused an issue on ACL Manager. See below the error thrown:

```
[ErrorException]                                                                                                                                                                                                                 
  Declaration of LaravelDoctrine\ACL\Manager::createDriver($driver, array $settings = Array) should be compatible with LaravelDoctrine\ORM\Configuration\Manager::createDriver($driver, array $settings = Array, $resolve = true) 
```

This change should solve it.
