### PR TITLE
Fix: hasPermissionTo fail check if object provided

### DIFF
--- a/src/Permissions/HasPermissions.php
+++ b/src/Permissions/HasPermissions.php
@@ -30,7 +30,7 @@ trait HasPermissions
         } else {
             if ($this instanceof HasPermissionsContract) {
                 foreach ($this->getPermissions() as $permission) {
-                    if ($this->getPermissionName($permission) === $name) {
+                    if ($this->getPermissionName($permission) === $this->getPermissionName($name)) {
                         return true;
                     }
                 }

--- a/tests/Permissions/HasPermissionsTest.php
+++ b/tests/Permissions/HasPermissionsTest.php
@@ -180,6 +180,20 @@ class HasPermissionsTest extends PHPUnit_Framework_TestCase
 
         $this->assertTrue($this->user->hasPermissionTo(['create.post', 'create.page'], true));
     }
+
+    public function test_user_has_permission_by_object()
+    {
+        $this->user->setPermissions(['test.test']);
+
+        $this->assertTrue($this->user->hasPermissionTo(new \LaravelDoctrine\ACL\Permissions\Permission('test.test')));
+    }
+
+    public function test_user_has_object_permission_by_object()
+    {
+        $this->user->setPermissions([new \LaravelDoctrine\ACL\Permissions\Permission('test.test')]);
+
+        $this->assertTrue($this->user->hasPermissionTo(new \LaravelDoctrine\ACL\Permissions\Permission('test.test')));
+    }
 }
 
 class UserMock implements HasPermissionsContract


### PR DESCRIPTION
Hey,

Great package! But it failed on really simple use case :)

Validation failing if provide PermissionContact to HasPermissionsContract::hasPermissionTo.
