### PR TITLE
(possible) fix for not reading custom acl configuration

### DIFF
--- a/src/AclServiceProvider.php
+++ b/src/AclServiceProvider.php
@@ -78,6 +78,10 @@ class AclServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(
             $this->getConfigPath(), 'acl'
         );
+
+        if($this->isLumen()){
+            $this->app->configure('acl');
+        }
     }
 
     /**

--- a/src/AclServiceProvider.php
+++ b/src/AclServiceProvider.php
@@ -79,7 +79,7 @@ class AclServiceProvider extends ServiceProvider
             $this->getConfigPath(), 'acl'
         );
 
-        if($this->isLumen()){
+        if ($this->isLumen()) {
             $this->app->configure('acl');
         }
     }


### PR DESCRIPTION
We ran into an issue where in lumen our custom acl.php configuration wasn't included
This is a fix for that allowing one to override the acl.php configuration that is defined by default
