### PR TITLE
Fixes null object call on generate:entities

### DIFF
--- a/src/Mappings/Subscribers/MappedEventSubscriber.php
+++ b/src/Mappings/Subscribers/MappedEventSubscriber.php
@@ -121,7 +121,7 @@ abstract class MappedEventSubscriber implements EventSubscriber
             return false;
         }
 
-        if ($metadata->getReflectionClass()->isAbstract()) {
+        if (!$metadata->getReflectionClass() || $metadata->getReflectionClass()->isAbstract()) {
             return false;
         }
 


### PR DESCRIPTION
Fixes [BUG] Call to member function isAbstract on null in mappedEventSubscriber doctrine:generate:entities

This seems to be related to the following issue filed on the doctrine github:

https://github.com/doctrine/doctrine2/issues/4459

and the following pull request:

https://github.com/doctrine/doctrine2/pull/1345

The generate:entities command uses the `DisconnectedClassMetadataFactory` and so `getReflectionClass` isn't guaranteed to return anything and can be null, as such the following lines in `LaravelDoctrine\ACL\Mappings\Subscribers\MappedEventSubscriber` should be changed:

From:

```
    /**
     * A MappedSuperClass or Abstract class cannot be instantiated.
     *
     * @param ClassMetadata $metadata
     *
     * @return bool
     */
    protected function isInstantiable(ClassMetadata $metadata)
    {
        if ($metadata->isMappedSuperclass) {
            return false;
        }

        if ($metadata->getReflectionClass()->isAbstract()) {
            return false;
        }

        return true;
    }
```

To:

```
    /**
     * A MappedSuperClass or Abstract class cannot be instantiated.
     *
     * @param ClassMetadata $metadata
     *
     * @return bool
     */
    protected function isInstantiable(ClassMetadata $metadata)
    {
        if ($metadata->isMappedSuperclass) {
            return false;
        }

        if (!$metadata->getReflectionClass() || $metadata->getReflectionClass()->isAbstract()) {
            return false;
        }

        return true;
    }
```

I've tried it and it seems to work fine after that - but I don't know if this will affect anything else internally.
