### PR TITLE
Fixed mapping subscribers for Laravel 5.4

### DIFF
--- a/src/RegisterMappedEventSubscribers.php
+++ b/src/RegisterMappedEventSubscribers.php
@@ -46,7 +46,10 @@ class RegisterMappedEventSubscribers implements DoctrineExtender
     {
         foreach ($this->subscribers as $subscriber) {
             $eventManager->addEventSubscriber(
-                $this->container->make($subscriber, [$configuration->getMetadataDriverImpl()->getReader()])
+                new $subscriber(
+                    $configuration->getMetadataDriverImpl()->getReader(),
+                    $this->container['config']
+                )
             );
         }
     }


### PR DESCRIPTION
In Laravel 5.4 the ability to provide parameters to `make` was removed, this change reworks the instantiation of subscribers so that they are no longer resolved from the container.

This change should be compatible with previous Laravel versions.