### PR TITLE
Catch exception when fetching permissions

### DIFF
--- a/tests/Permissions/DoctrinePermissionDriverTest.php
+++ b/tests/Permissions/DoctrinePermissionDriverTest.php
@@ -11,6 +11,7 @@ use LaravelDoctrine\ACL\Permissions\ConfigPermissionDriver;
 use LaravelDoctrine\ACL\Permissions\DoctrinePermissionDriver;
 use LaravelDoctrine\ACL\Permissions\Permission;
 use Mockery as m;
+use Illuminate\Contracts\Logging\Log;
 
 class DoctrinePermissionDriverTest extends PHPUnit_Framework_TestCase
 {
@@ -33,13 +34,19 @@ class DoctrinePermissionDriverTest extends PHPUnit_Framework_TestCase
      * @var Mockery\Mock
      */
     protected $em;
+    
+    /**
+     * @var Mockery\Mock
+     */
+    protected $log;
 
     protected function setUp()
     {
         $this->config   = m::mock(Repository::class);
         $this->registry = m::mock(ManagerRegistry::class);
         $this->em       = m::mock(EntityManagerInterface::class);
-        $this->driver   = new DoctrinePermissionDriver($this->registry, $this->config);
+        $this->log      = m::mock(Log::class);
+        $this->driver   = new DoctrinePermissionDriver($this->registry, $this->config, $this->log);
     }
 
     public function test_can_get_all_permissions()


### PR DESCRIPTION
**Scenario:** I had my own Permission class, and added a new column to it, and I get hit by exceptions when attempting to generate new migrations.

**Possible BC**: If users has extended DoctrinePermissionDriver, there is now a new argument for log class. I considered using a facade, but they might not be available.

As this might cause problems when database structure has changed in
mapping, but users is attempting to execute doctrine:migrations commands
they get hit with exceptions and thus makes the commands unusable until
they change the vendor code. It's better in this situation to just catch
any exception and then logging it, hoping that users check their logs.