### PR TITLE
Fixes laravel-doctrine/acl#25

### DIFF
--- a/src/AclServiceProvider.php
+++ b/src/AclServiceProvider.php
@@ -25,8 +25,8 @@ class AclServiceProvider extends ServiceProvider
 
         $this->app->make(DoctrineManager::class)->onResolve(function () {
             $this->definePermissions(
-                $this->app->make(Gate::class),
-                $this->app->make(PermissionManager::class)
+                app(Gate::class),
+                app(PermissionManager::class)
             );
         });
     }

--- a/src/RegisterMappedEventSubscribers.php
+++ b/src/RegisterMappedEventSubscribers.php
@@ -5,7 +5,6 @@ namespace LaravelDoctrine\ACL;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Configuration;
-use Illuminate\Contracts\Container\Container;
 use LaravelDoctrine\ACL\Mappings\Subscribers\BelongsToOrganisationsSubscriber;
 use LaravelDoctrine\ACL\Mappings\Subscribers\BelongsToOrganisationSubscriber;
 use LaravelDoctrine\ACL\Mappings\Subscribers\HasPermissionsSubscriber;
@@ -25,19 +24,6 @@ class RegisterMappedEventSubscribers implements DoctrineExtender
     ];
 
     /**
-     * @var Container
-     */
-    protected $container;
-
-    /**
-     * @param Container $container
-     */
-    public function __construct(Container $container)
-    {
-        $this->container = $container;
-    }
-
-    /**
      * @param Configuration $configuration
      * @param Connection    $connection
      * @param EventManager  $eventManager
@@ -48,7 +34,7 @@ class RegisterMappedEventSubscribers implements DoctrineExtender
             $eventManager->addEventSubscriber(
                 new $subscriber(
                     $configuration->getMetadataDriverImpl()->getReader(),
-                    $this->container['config']
+                    app('config')
                 )
             );
         }


### PR DESCRIPTION
Target [Illuminate\Contracts\Container\Container] is not instantiable while building [LaravelDoctrine\ACL\RegisterMappedEventSubscribers]