### PR TITLE
Changed tableExists check to be less resource intensive for large clusters

### DIFF
--- a/tests/Permissions/DoctrinePermissionDriverTest.php
+++ b/tests/Permissions/DoctrinePermissionDriverTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\DBAL\Driver\Connection;
-use Doctrine\DBAL\Schema\MySqlSchemaManager;
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Driver\Mysqli\Driver;
+use Doctrine\DBAL\Driver\Mysqli\MysqliException;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Illuminate\Contracts\Config\Repository;
@@ -60,16 +61,34 @@ class DoctrinePermissionDriverTest extends PHPUnit_Framework_TestCase
         ];
         $this->em->shouldReceive('getClassMetadata')->once()->andReturn($meta);
 
-        $connection = m::mock(Connection::class);
-        $this->em->shouldReceive('getConnection')->once()->andReturn($connection);
-
-        $schema = m::mock(MySqlSchemaManager::class);
-        $connection->shouldReceive('getSchemaManager')->once()->andReturn($schema);
-
-        $schema->shouldReceive('tablesExist')->with(['permissions'])->andReturn(true);
-
         $permissions = $this->driver->getAllPermissions();
         $this->assertInstanceOf(Collection::class, $permissions);
         $this->assertTrue($permissions->contains('mocked'));
+    }
+
+    public function test_should_not_fail_when_table_does_not_exist()
+    {
+        $this->config->shouldReceive('get')->with('acl.permissions.entity')->once()->andReturn(Permission::class);
+
+        $this->registry->shouldReceive('getManagerForClass')->with(Permission::class)->once()->andReturn($this->em);
+
+        $this->em->shouldReceive('getUnitOfWork')->once()->andReturn($this->em);
+        $this->em->shouldReceive('getEntityPersister')->with(Permission::class)->once()->andReturn($this->em);
+
+        $driver = new Driver();
+        $exception = new MysqliException('Base table or view not found: 1146 Table \'permissions\' doesn\'t exist', 1146, 1146);
+        $tableNotFoundException = DBALException::driverExceptionDuringQuery($driver, $exception, 'SELECT t0.id AS id_1, t0.name AS name_2, t0.modules AS modules_3 FROM permissions t0');
+
+        $this->em->shouldReceive('loadAll')->once()->andThrow($tableNotFoundException);
+
+        $meta        = new ClassMetadata(Permission::class);
+        $meta->table = [
+            'name' => 'permissions',
+        ];
+        $this->em->shouldReceive('getClassMetadata')->once()->andReturn($meta);
+
+        $permissions = $this->driver->getAllPermissions();
+        $this->assertInstanceOf(Collection::class, $permissions);
+        $this->assertTrue($permissions->isEmpty());
     }
 }


### PR DESCRIPTION
The tableExists function executes a query that takes approximately 6 seconds on our database cluster.
Since this query is executed twice on every page load, requests are quite slow.

This method is a bit less resource intensive that the previous one