### PR TITLE
Fixes laravel-doctrine/acl#25

### DIFF
--- a/src/AclServiceProvider.php
+++ b/src/AclServiceProvider.php
@@ -3,6 +3,7 @@
 namespace LaravelDoctrine\ACL;
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Support\ServiceProvider;
 use LaravelDoctrine\ACL\Contracts\HasPermissions;
@@ -23,10 +24,12 @@ class AclServiceProvider extends ServiceProvider
             ], 'config');
         }
 
-        $this->app->make(DoctrineManager::class)->onResolve(function () {
+        $this->app->get(DoctrineManager::class)->onResolve(function () {
+            $container = Container::getInstance();
+
             $this->definePermissions(
-                $this->app->make(Gate::class),
-                $this->app->make(PermissionManager::class)
+                $container->get(Gate::class),
+                $container->get(PermissionManager::class)
             );
         });
     }

--- a/src/RegisterMappedEventSubscribers.php
+++ b/src/RegisterMappedEventSubscribers.php
@@ -5,6 +5,8 @@ namespace LaravelDoctrine\ACL;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Configuration;
+use Doctrine\ORM\ORMException;
+use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Container\Container;
 use LaravelDoctrine\ACL\Mappings\Subscribers\BelongsToOrganisationsSubscriber;
 use LaravelDoctrine\ACL\Mappings\Subscribers\BelongsToOrganisationSubscriber;
@@ -23,7 +25,6 @@ class RegisterMappedEventSubscribers implements DoctrineExtender
         HasRolesSubscriber::class,
         HasPermissionsSubscriber::class,
     ];
-
     /**
      * @var Container
      */
@@ -41,14 +42,18 @@ class RegisterMappedEventSubscribers implements DoctrineExtender
      * @param Configuration $configuration
      * @param Connection    $connection
      * @param EventManager  $eventManager
+     *
+     * @throws ORMException
      */
     public function extend(Configuration $configuration, Connection $connection, EventManager $eventManager)
     {
+        $configRepository = \Illuminate\Container\Container::getInstance()->get(Repository::class);
+
         foreach ($this->subscribers as $subscriber) {
             $eventManager->addEventSubscriber(
                 new $subscriber(
                     $configuration->getMetadataDriverImpl()->getReader(),
-                    $this->container['config']
+                    $configRepository
                 )
             );
         }


### PR DESCRIPTION
Target [Illuminate\Contracts\Container\Container] is not instantiable while building [LaravelDoctrine\ACL\RegisterMappedEventSubscribers]